### PR TITLE
Priority gen

### DIFF
--- a/ems/datasets/case/random_case_set.py
+++ b/ems/datasets/case/random_case_set.py
@@ -6,6 +6,7 @@ from ems.generators.duration.duration import DurationGenerator
 from ems.generators.location.location import LocationGenerator
 from ems.generators.event.event_generator import EventGenerator
 from ems.generators.priority.priority import PriorityGenerator
+from ems.generators.priority.random import RandomPriorityGenerator
 
 from ems.models.cases.random_case import RandomCase
 
@@ -17,8 +18,8 @@ class RandomCaseSet(CaseSet):
                  time: datetime,
                  case_time_generator: DurationGenerator,
                  case_location_generator: LocationGenerator,
-                 case_priority_generator: PriorityGenerator,
                  event_generator: EventGenerator,
+                 case_priority_generator: PriorityGenerator = RandomPriorityGenerator(),
                  quantity: int = None):
         super().__init__(time)
         self.time = time
@@ -33,7 +34,7 @@ class RandomCaseSet(CaseSet):
 
         while self.quantity is None or k <= self.quantity:
             # Compute time and location of next event via generators
-            duration = self.case_time_generator.generate(timestamp=self.time)
+            duration = self.case_time_generator.generate(timestamp=self.time)["duration"]
 
             self.time = self.time + duration
             point = self.location_generator.generate(self.time)

--- a/ems/datasets/case/random_case_set.py
+++ b/ems/datasets/case/random_case_set.py
@@ -5,10 +5,9 @@ from ems.generators.duration.duration import DurationGenerator
 
 from ems.generators.location.location import LocationGenerator
 from ems.generators.event.event_generator import EventGenerator
+from ems.generators.priority.priority import PriorityGenerator
 
 from ems.models.cases.random_case import RandomCase
-from random import randint
-from numpy.random import choice
 
 
 # Implementation of a case set that randomly generates cases while iterating
@@ -18,12 +17,14 @@ class RandomCaseSet(CaseSet):
                  time: datetime,
                  case_time_generator: DurationGenerator,
                  case_location_generator: LocationGenerator,
+                 case_priority_generator: PriorityGenerator,
                  event_generator: EventGenerator,
                  quantity: int = None):
         super().__init__(time)
         self.time = time
         self.case_time_generator = case_time_generator
         self.location_generator = case_location_generator
+        self.priority_generator = case_priority_generator
         self.event_generator = event_generator
         self.quantity = quantity
 
@@ -32,46 +33,22 @@ class RandomCaseSet(CaseSet):
 
         while self.quantity is None or k <= self.quantity:
             # Compute time and location of next event via generators
-
-            time = self.case_time_generator.generate(timestamp=self.time)
-            duration = time['duration']
-            disaster = time.get('disaster', False)
+            duration = self.case_time_generator.generate(timestamp=self.time)
 
             self.time = self.time + duration
             point = self.location_generator.generate(self.time)
-
-            # MAURICIO: THIS MUST BE DONE AT THE GENERATORS!
-            # TODO: SEE IF I MADE SOMETHING REALLY BAD
-            # disaster = self.case_time_generator.lmda
-            # disaster = True if lmda > 0.3 else False
-            # A high lambda signifies a disaster scenario. This means higher
-            # severity cases occur.
-            # TODO I am wondering if something is wrong with the way the below
-            # TODO severity code has with the above self.time and generator code.
-
-            if disaster:
-                severity = choice(
-                                  [1,2,3,4],
-                                  p=[0.6, 0.2, 0.1, 0.1]
-                              )
-            else:
-                severity = choice(
-                    [1, 2, 3, 4],
-                    p=[0.03397097625329815, 0.03781882145998241,
-                       0.1994283201407212, 0.7287818821459983]
-                )
+            priority = self.priority_generator.generate(self.time)
 
             # Create case
             case = RandomCase(id=k,
                               date_recorded=self.time,
                               incident_location=point,
                               event_generator=self.event_generator,
-                              priority=severity
-                              )
+                              priority=priority)
 
             k += 1
 
             yield case
 
     def __len__(self):
-        return self.num_cases
+        return self.quantity

--- a/ems/generators/duration/poisson_duration.py
+++ b/ems/generators/duration/poisson_duration.py
@@ -24,4 +24,5 @@ class PoissonDurationGenerator(DurationGenerator):
                  timestamp: datetime = None):
         rand = -math.log(1.0 - random.random())
         minutes_until_next = rand / self.lmda
-        return timedelta(minutes=minutes_until_next)
+        return {'duration': timedelta(minutes=minutes_until_next)}
+

--- a/ems/generators/duration/poisson_duration.py
+++ b/ems/generators/duration/poisson_duration.py
@@ -24,7 +24,4 @@ class PoissonDurationGenerator(DurationGenerator):
                  timestamp: datetime = None):
         rand = -math.log(1.0 - random.random())
         minutes_until_next = rand / self.lmda
-        return {
-            'duration': timedelta(minutes=minutes_until_next),
-            'disaster': self.lmda > 0.3
-        }
+        return timedelta(minutes=minutes_until_next)

--- a/ems/generators/location/multiple_polygon.py
+++ b/ems/generators/location/multiple_polygon.py
@@ -2,8 +2,6 @@ from numpy.random import choice
 from typing import List
 import yaml
 
-from geopy import Point
-
 from ems.generators.location.location import LocationGenerator
 from ems.generators.location.polygon import PolygonLocationGenerator
 
@@ -13,9 +11,10 @@ class MultiPolygonLocationGenerator(LocationGenerator):
     A region is divided into a set of regions so that the region can simulate certain zones
     having more cases occurring than others.
     """
+
     def __init__(self,
-                 each_polygons_longitudes: List[List[float]] = None,
-                 each_polygons_latitudes: List[List[float]] = None,
+                 longitudes: List[List[float]] = None,
+                 latitudes: List[List[float]] = None,
                  longitudes_file: str = None,
                  latitudes_file: str = None,
                  densities: List[float] = None):
@@ -25,40 +24,32 @@ class MultiPolygonLocationGenerator(LocationGenerator):
         :param densities: The probability for each polygon respectively to each polygon.
         """
 
-        if not any([each_polygons_latitudes and each_polygons_longitudes, longitudes_file and latitudes_file]):
-            raise Exception("Either pass in the lats and lons as list of list of floats or as file names")
+        if not any([latitudes and longitudes, longitudes_file and latitudes_file]):
+            raise Exception("No polygon coordinates specified")
 
-        if not each_polygons_longitudes:
+        if not longitudes:
             with open(longitudes_file, 'r') as lons_file:
-                each_polygons_longitudes = yaml.full_load(lons_file)
+                longitudes = yaml.load(lons_file)
 
-        if not each_polygons_latitudes:
+        if not latitudes:
             with open(latitudes_file, 'r') as lats_file:
-                each_polygons_latitudes = yaml.full_load(lats_file)
+                latitudes = yaml.load(lats_file)
 
-        # Check all the assumptions in the beginning of the function.
-        assert len(each_polygons_longitudes) == len(each_polygons_latitudes)
-        for i in range(len(each_polygons_longitudes)):
-            assert len(each_polygons_longitudes[i]) == len(each_polygons_latitudes[i])
-            for f in each_polygons_longitudes[i]:
-                assert isinstance(f, float)
-            for f in each_polygons_latitudes[i]:
-                assert isinstance(f, float)
-
-
+        # Set densities
         if densities is None:
-            self.densities = [1 / len(each_polygons_longitudes) for _ in each_polygons_longitudes]
-
+            self.densities = [1 / len(longitudes) for _ in longitudes]
         else:
-            assert(sum(densities) == 1.0) # Sum of probabilities should add up to 100%
-            assert len(densities) == len(each_polygons_longitudes)
-
             self.densities = densities
 
-        # self.polygon_generators = self.create_generators(each_polygons_longitudes, each_polygons_latitudes)
-        self.polygon_generators = [PolygonLocationGenerator(each_polygons_longitudes[i], each_polygons_latitudes[i])
-                                   for i in range(len(each_polygons_longitudes))]
+        # Validate function args
+        if sum(densities) == 1.0:
+            raise Exception("Sum of densities should add up to 100%")
+        if len(densities) != len(longitudes):
+            raise Exception("Provided polygons and densities are not equal in length")
 
+        # self.polygon_generators = self.create_generators(each_polygons_longitudes, each_polygons_latitudes)
+        self.polygon_generators = [PolygonLocationGenerator(longitudes[i], latitudes[i])
+                                   for i in range(len(longitudes))]
 
     def generate(self, timestamp=None):
         """
@@ -69,19 +60,3 @@ class MultiPolygonLocationGenerator(LocationGenerator):
         """
         generator = choice(self.polygon_generators, 1, p=self.densities)[0]
         return generator.generate(timestamp)
-
-
-    @staticmethod # Why is this a static method?
-    def create_generators(list_lons, list_lats):
-        """
-        One uniform distribution random location generator per region.
-
-        :param polygons:
-        :return:
-        """
-        return
-        # polygon_generators = []
-        # for points in polygons:
-        #     polygon_generator = PolygonLocationGenerator(points)
-        #     polygon_generators.append(polygon_generator)
-        # return polygon_generators

--- a/ems/generators/location/multiple_polygon.py
+++ b/ems/generators/location/multiple_polygon.py
@@ -42,7 +42,7 @@ class MultiPolygonLocationGenerator(LocationGenerator):
             self.densities = densities
 
         # Validate function args
-        if sum(densities) == 1.0:
+        if sum(densities) != 1.0:
             raise Exception("Sum of densities should add up to 100%")
         if len(densities) != len(longitudes):
             raise Exception("Provided polygons and densities are not equal in length")

--- a/ems/generators/priority/priority.py
+++ b/ems/generators/priority/priority.py
@@ -1,0 +1,8 @@
+# Interface for a priority generator
+class PriorityGenerator:
+
+    def __init__(self, priorities):
+        self.priorities = priorities
+
+    def generate(self, timestamp=None):
+        raise NotImplementedError()

--- a/ems/generators/priority/random.py
+++ b/ems/generators/priority/random.py
@@ -10,11 +10,18 @@ class RandomPriorityGenerator(PriorityGenerator):
 
         if priorities is None:
             priorities = [1, 2, 3, 4]
+        self.priorities = priorities
 
         if distribution is None:
             self.dist = [1 / len(priorities) for _ in priorities]
         else:
             self.dist = distribution
+
+        # Validate function args
+        if sum(self.dist) != 1.0:
+            raise Exception("Sum of dist should add up to 100%")
+        if len(self.dist) != len(priorities):
+            raise Exception("Provided dist and priorities are not equal in length")
 
     def generate(self, timestamp=None):
         # Randomly choose

--- a/ems/generators/priority/random.py
+++ b/ems/generators/priority/random.py
@@ -1,0 +1,21 @@
+# Generates a priority from a probabilistic distribution
+from ems.generators.priority.priority import PriorityGenerator
+from numpy.random import choice
+
+
+class RandomPriorityGenerator(PriorityGenerator):
+
+    def __init__(self, priorities=None, distribution=None):
+        super().__init__(priorities=priorities)
+
+        if priorities is None:
+            priorities = [1, 2, 3, 4]
+
+        if distribution is None:
+            self.dist = [1 / len(priorities) for _ in priorities]
+        else:
+            self.dist = distribution
+
+    def generate(self, timestamp=None):
+        # Randomly choose
+        return choice(self.priorities, 1, p=self.dist)[0]


### PR DESCRIPTION
@hansyuan Priority generator added to random case set.

- There is a provided default for the priority generator that generates cases with priorities 1-4 randomly with equal chance. This means that minimal.yaml and simple.yaml do not need to be changed to add the priority gen
- For the CruzRoja yaml, we will need to add a definition for priority generator to each case set. e.g.

```
p_gen: 
  class: ems.generators.priority.RandomPriorityGenerator
  priorities: [1, 2, 3, 4]
  distribution: [0.2, 0.5, 0.15, 0.15]

cases:
  ...
  case_priority_generator: $p_gen
  ...
```