### PR TITLE
Import lib fixed to support absolute import

### DIFF
--- a/ems/run.py
+++ b/ems/run.py
@@ -43,17 +43,14 @@ class Driver:
             for key, value in param.items():
                 # Parse into class and classname
                 if key == "class":
-                    cname_parts = value.split('.')
-                    cname = cname_parts[-1]
-                    cpath = '.'.join(cname_parts[1:-1])
-                    pname = cname_parts[0]
+                    cpath, cname = value.rsplit('.', 1)
 
                 # Parameter: recurse to create object for parameter
                 else:
                     params[key] = Driver._create_recurse(value, objects)
 
             # print("Instantiating: {}".format(cname)) # TODO Change to log
-            c = getattr(importlib.import_module('.' + cpath, pname), cname)
+            c = getattr(importlib.import_module(cpath), cname)
             instance = c(**params)
             return instance
 


### PR DESCRIPTION
**Important PR!**

Small change, but absolutely necessary for simulation customization. Now, users can specify their own classes in the YAML if they have custom functionality written. For example:

Let some file C be in location ./A/B/ 
Let D be a class for an ambulance selector in file C

To specify the custom file in the YAML:

```
ambulance_selector:
  class: A.B.C.D
```

For some extra crazy shenanigans, you could build your own library with custom functionality and then use the same syntax to import from it.